### PR TITLE
QGC-Gov Changes

### DIFF
--- a/src/KlvParser.cpp
+++ b/src/KlvParser.cpp
@@ -203,7 +203,7 @@ std::shared_ptr<KLV> KlvParser::parseByte(uint8_t byte) {
                     if(i == 0) {
                         // beginning
                         sub_klvs[i]->setNextSibling(sub_klvs[i+1]);
-                    } else if(i == sub_klvs.size()) {
+                    } else if(i == (sub_klvs.size() - 1)) {
                         // end
                         sub_klvs[i]->setPreviousSibling(sub_klvs[i-1]);
                     } else {

--- a/src/KlvParser.cpp
+++ b/src/KlvParser.cpp
@@ -194,24 +194,26 @@ std::shared_ptr<KLV> KlvParser::parseByte(uint8_t byte) {
                 }
             }
 
-            // assign child of THIS klv to the first child in the vector
-            klv->setChild(sub_klvs[0]);
+            if(sub_klvs.size() > 0) {
+                // assign child of THIS klv to the first child in the vector
+                klv->setChild(sub_klvs[0]);
 
-            // assign the next and previous sibling fields and the parent field in each of the sub_klvs
-            for(i = 0; i < sub_klvs.size(); i++) {
-                if(sub_klvs.size() > 1) {
-                    if(i == 0) {
-                        // beginning
-                        sub_klvs[i]->setNextSibling(sub_klvs[i+1]);
-                    } else if(i == (sub_klvs.size() - 1)) {
-                        // end
-                        sub_klvs[i]->setPreviousSibling(sub_klvs[i-1]);
-                    } else {
-                        sub_klvs[i]->setNextSibling(sub_klvs[i+1]);
-                        sub_klvs[i]->setPreviousSibling(sub_klvs[i-1]);
+                // assign the next and previous sibling fields and the parent field in each of the sub_klvs
+                for(i = 0; i < sub_klvs.size(); i++) {
+                    if(sub_klvs.size() > 1) {
+                        if(i == 0) {
+                            // beginning
+                            sub_klvs[i]->setNextSibling(sub_klvs[i+1]);
+                        } else if(i == (sub_klvs.size() - 1)) {
+                            // end
+                            sub_klvs[i]->setPreviousSibling(sub_klvs[i-1]);
+                        } else {
+                            sub_klvs[i]->setNextSibling(sub_klvs[i+1]);
+                            sub_klvs[i]->setPreviousSibling(sub_klvs[i-1]);
+                        }
                     }
+                    sub_klvs[i]->setParent(klv);
                 }
-                sub_klvs[i]->setParent(klv);
             }
         }
         

--- a/src/KlvParser.cpp
+++ b/src/KlvParser.cpp
@@ -115,11 +115,18 @@ std::shared_ptr<KLV> KlvParser::parseByte(uint8_t byte) {
             //printf("BER len: %ld\n", ber_len);
             //printf("KlvParser transitioning to STATE_LEN_HEADER\n");
         } else {
-            state = STATE_LEN;
             val_len = byte & 0b01111111;
-            //printf("BER-Len field is short-form\n");
             //printf("Value length: %ld\n", val_len);
-            //printf("KlvParser transitioning to STATE_LEN\n");
+            if(val_len == 0) {
+                //printf("BER-Len field is zero-length (ZLI)\n");
+                std::shared_ptr<KLV> klv = std::make_shared<KLV>(key, len, val);
+                resetFields();
+                return klv;
+            } else {
+                state = STATE_LEN;
+                //printf("BER-Len field is short-form\n");
+                //printf("KlvParser transitioning to STATE_LEN\n");
+            }
         }
         break;
     }


### PR DESCRIPTION
Pulling changes from the QGC-Gov-Changes branch into master. Since we're bringing tactical view to AMC, we need the version of this library used in AMC to now match what QGC-Gov is using. 

1. The first two commits here are from last fall and are just bugfixes for how nested KLV items are treated.
2. The third commit I just now made and it is adding support for zero-length-items. 
	+ ZLI is called out in section 6.3.4 of MISB 0107.
	+ MISB 0107 is a sub-requirement of MISB 0601 as listed its section 6.1.
	+ MISB 0601 is a requirement of RAS-A.
	+ Links here: [MISB 0601](https://upload.wikimedia.org/wikipedia/commons/1/19/MISB_Standard_0601.pdf) [MISB 0107](https://sightlineapplications.com/misb-standards/MISB-ST-0107.5.pdf)

### Testing

I've been working with Skydio and have confirmation that the ZLI changes work with the latest software they've been developing for the X2D.

We seem to have removed the cmakelists.txt from this repo, but if you pull it in from [the upstream repo](https://github.com/Hunter522/libklv/tree/master), and modify the test as follows, you can check for ZLI.

__KlvParserTest.cpp, line 78__
```cpp
TEST_F(KlvParserTest, TestTree) {
    // test that the tree is constructed correctly
std::vector<uint8_t> test_pkt_uas = {
	0x06, 0x0E, 0x2B, 0x34, 0x02, 0x0B, 0x01, 0x01, 0x0E, 0x01, 0x03, 0x01,
	0x01, 0x00, 0x00, 0x00, 0x81, 0x92, 0x02, 0x08, 0x00, 0x04, 0x6C, 0xAE, 
	0x70, 0xF9, 0x80, 0xCF, 0x41, 0x01, 0x01, 0x05, 0x02, 0xE1, 0x91, 0x06, 
	0x02, 0x06, 0x0D, 0x07, 0x02, 0x0A, 0xE1, 0x0B, 0x02, 0x49, 0x52, 0x0C, 
	0x0E, 0x47, 0x65, 0x6F, 0x64, 0x65, 0x74, 0x69, 0x63, 0x20, 0x57, 0x47, 
	0x53, 0x38, 0x34, 0x0D, 0x04, 0x4D, 0xCC, 0x41, 0x90, 0x0E, 0x04, 0xB1, 
	0xD0, 0x3D, 0x96, 0x0F, 0x02, 0x1B, 0x2E, 0x10, 0x02, 0x00, 0x84, 0x11, 
	0x02, 0x00, 0x4A, 0x12, 0x04, 0xE7, 0x23, 0x0B, 0x61, 0x13, 0x04, 0xFD, 
	0xE8, 0x63, 0x8E, 0x14, 0x04, 0x03, 0x0B, 0xC7, 0x1C, 0x15, 0x04, 0x00, 
	0x9F, 0xB9, 0x38, 0x16, 0x04, 0x00, 0x00, 0x01, 0xF8, 0x17, 0x04, 0x4D, 
	0xEC, 0xDA, 0xF4, 0x18, 0x04, 0xB1, 0xBC, 0x81, 0x74, 0x19, 0x02, 0x0B, 
	0x8A, 0x28, 0x04, 0x4D, 0xEC, 0xDA, 0xF4, 0x29, 0x04, 0xB1, 0xBC, 0x81, 
	0x74, 0x2A, 0x02, 0x0B, 0x8A, 0x38, 0x01, 0x31,
 	/* key, and length, (no value) for ZLI --> */   0x77, 0x00, 
																0x39, 0x04,
	0x00, 0x9F, 0x85, 0x4D, 0x01, 0x02, 0xB7, 0xEB};
```